### PR TITLE
feat: change pattern, expand skip options

### DIFF
--- a/main.py
+++ b/main.py
@@ -11,6 +11,8 @@ from validator import extractUrl, isSupportedUrl
 from dbInteraction import savePost, doesPostExist
 from concurrent.futures import ThreadPoolExecutor
 
+SKIP_STRINGS = ['🙅‍♂️', '🙅‍♀️', '❌']
+
 load_dotenv()
 
 intents = discord.Intents.default()
@@ -257,8 +259,8 @@ async def handleMessage(message):
 
         print(f"Got URL: {url} For User: {message.author}")
 
-        # Skip if no download is requested
-        if '🙅‍♂️' in message.content or '🙅‍♀️' in message.content:
+        # Skip download if any skip strings are present
+        if any(skip_str in message.content for skip_str in SKIP_STRINGS):
             return
 
         silentMode = False


### PR DESCRIPTION
This PR contains a suggestion for a pattern of checking for skip messages, to simplify expanding skip options.

This suggestion comes from guessing at a skip pattern earlier (or rather from trying to avoid the bot detecting the link while keeping it clickable) wherein I used the :x: emoji, and put the link later in the message.

⚠️: I checked this pattern worked on python 3.13.7, but have not run the bot itself.

---

Another possible suggestion could be checking for the presence of a link at the start of a message, but this may be less intuitive.

Feel free to close, reject etc just adding thoughts.