### PR TITLE
Add management UI for repost cleanup

### DIFF
--- a/dbInteraction.py
+++ b/dbInteraction.py
@@ -1,34 +1,75 @@
 import psycopg2
-from dotenv import load_dotenv 
+from dotenv import load_dotenv
 import os
 from datetime import datetime
 
+conn = None
+
 try:
-	load_dotenv()
-	host = os.getenv('DB_HOST')
-	dbUser = os.getenv('DB_USER')
-	dbPass = os.getenv('DB_PASS')
-	dbName = os.getenv('DB_NAME')
-	conn = psycopg2.connect(f"host={host} dbname={dbName} user={dbUser} password={dbPass}")
+    load_dotenv()
+    host = os.getenv('DB_HOST')
+    dbUser = os.getenv('DB_USER')
+    dbPass = os.getenv('DB_PASS')
+    dbName = os.getenv('DB_NAME')
+    conn = psycopg2.connect(f"host={host} dbname={dbName} user={dbUser} password={dbPass}")
 except Exception as e:
     print("Cannot load DB details, repost detection will not be available: " + str(e))
 
+
+def is_db_available():
+    return conn is not None
+
 def savePost(userId, postId, platform, messageId):
+    if not conn:
+        return
 
-	cur = conn.cursor()
+    cur = conn.cursor()
 
-	cur.execute("INSERT INTO posts (\"userId\", \"videoId\", \"platform\", \"postDateTime\", \"discordMessageId\") VALUES (%s, %s, %s, %s, %s)", (userId, postId, platform, datetime.now(tz=None), messageId))
+    cur.execute(
+        "INSERT INTO posts (\"userId\", \"videoId\", \"platform\", \"postDateTime\", \"discordMessageId\") VALUES (%s, %s, %s, %s, %s)",
+        (userId, postId, platform, datetime.now(tz=None), messageId),
+    )
 
-	conn.commit()
+    conn.commit()
 
-	cur.close()
+    cur.close()
 
 def doesPostExist(videoId, platform):
-	cur = conn.cursor()
-	cur.execute("SELECT \"userId\", \"postDateTime\", \"discordMessageId\" FROM posts WHERE \"videoId\"=(%s) AND \"platform\"=(%s) ORDER BY \"postId\" DESC LIMIT 1", (videoId, platform))
-	result = cur.fetchone()
-	print("Heres the result:")
-	print(result)
+    if not conn:
+        return None
 
-	cur.close()
-	return result
+    cur = conn.cursor()
+    cur.execute(
+        "SELECT \"userId\", \"postDateTime\", \"discordMessageId\" FROM posts WHERE \"videoId\"=(%s) AND \"platform\"=(%s) ORDER BY \"postId\" DESC LIMIT 1",
+        (videoId, platform),
+    )
+    result = cur.fetchone()
+    print("Heres the result:")
+    print(result)
+
+    cur.close()
+    return result
+
+
+def fetchPosts(limit=50):
+    if not conn:
+        return []
+    cur = conn.cursor()
+    cur.execute(
+        "SELECT \"postId\", \"userId\", \"videoId\", \"platform\", \"postDateTime\", \"discordMessageId\" FROM posts ORDER BY \"postId\" DESC LIMIT %s",
+        (limit,),
+    )
+    rows = cur.fetchall()
+    cur.close()
+    return rows
+
+
+def deletePost(post_id):
+    if not conn:
+        return False
+    cur = conn.cursor()
+    cur.execute("DELETE FROM posts WHERE \"postId\"=(%s)", (post_id,))
+    deleted = cur.rowcount > 0
+    conn.commit()
+    cur.close()
+    return deleted

--- a/main.py
+++ b/main.py
@@ -5,6 +5,7 @@ import ffmpeg
 import traceback
 import asyncio
 import logging
+import threading
 from dotenv import load_dotenv 
 from downloader import download, download_with_retries
 from compressionMessages import getCompressionMessage
@@ -27,6 +28,15 @@ if not logging.getLogger().handlers:
         level=os.getenv("TIKBOT_LOG_LEVEL", "INFO"),
         format="%(asctime)s %(levelname)s %(name)s: %(message)s",
     )
+
+def start_management_ui():
+    enabled = os.getenv("TIKBOT_MANAGEMENT_UI_ENABLED", "true").lower() not in {"0", "false", "no"}
+    if not enabled:
+        return
+    from management_ui import run as run_management_ui
+    thread = threading.Thread(target=run_management_ui, name="management-ui", daemon=True)
+    thread.start()
+    logger.info("Management UI running on port %s", os.getenv("TIKBOT_MANAGEMENT_UI_PORT", "8080"))
 
 def get_file_size_limit():
     try:
@@ -425,4 +435,5 @@ async def on_message(message):
     await handleMessage(message)
 
 if __name__ == "__main__":
+    start_management_ui()
     client.run(os.getenv('TOKEN'))

--- a/management_ui.py
+++ b/management_ui.py
@@ -1,0 +1,123 @@
+import os
+from datetime import datetime
+from flask import Flask, redirect, render_template_string, request, url_for
+from dbInteraction import deletePost, fetchPosts, is_db_available
+
+TEMPLATE = """
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>TikBot Management</title>
+    <script src="https://cdn.tailwindcss.com"></script>
+  </head>
+  <body class="bg-slate-950 text-slate-100">
+    <div class="min-h-screen">
+      <header class="border-b border-slate-800">
+        <div class="mx-auto max-w-6xl px-6 py-6">
+          <h1 class="text-2xl font-semibold">TikBot Management</h1>
+          <p class="mt-1 text-sm text-slate-400">Review saved posts and delete reposts during testing.</p>
+        </div>
+      </header>
+
+      <main class="mx-auto max-w-6xl px-6 py-8">
+        {% if not db_available %}
+          <div class="rounded-lg border border-amber-500/40 bg-amber-500/10 p-4 text-amber-100">
+            Database connection not available. Configure DB_HOST, DB_USER, DB_PASS, and DB_NAME to manage reposts.
+          </div>
+        {% else %}
+          <div class="overflow-hidden rounded-lg border border-slate-800">
+            <div class="bg-slate-900/60 px-4 py-3 text-sm text-slate-300">Showing the most recent {{ posts|length }} posts</div>
+            <div class="overflow-x-auto">
+              <table class="min-w-full divide-y divide-slate-800 text-sm">
+                <thead class="bg-slate-900/80 text-left text-xs uppercase tracking-wider text-slate-400">
+                  <tr>
+                    <th class="px-4 py-3">Post ID</th>
+                    <th class="px-4 py-3">Platform</th>
+                    <th class="px-4 py-3">Video ID</th>
+                    <th class="px-4 py-3">User</th>
+                    <th class="px-4 py-3">Discord Message</th>
+                    <th class="px-4 py-3">Posted</th>
+                    <th class="px-4 py-3 text-right">Actions</th>
+                  </tr>
+                </thead>
+                <tbody class="divide-y divide-slate-900/70">
+                  {% for post in posts %}
+                  <tr class="hover:bg-slate-900/50">
+                    <td class="px-4 py-3 font-medium text-slate-200">{{ post.post_id }}</td>
+                    <td class="px-4 py-3 text-slate-300">{{ post.platform or '-' }}</td>
+                    <td class="px-4 py-3 text-slate-300">{{ post.video_id }}</td>
+                    <td class="px-4 py-3 text-slate-300">{{ post.user_id or '-' }}</td>
+                    <td class="px-4 py-3 text-slate-300">{{ post.discord_message_id or '-' }}</td>
+                    <td class="px-4 py-3 text-slate-300">{{ post.posted_at }}</td>
+                    <td class="px-4 py-3 text-right">
+                      <form method="post" action="{{ url_for('delete_post', post_id=post.post_id) }}" onsubmit="return confirm('Delete this repost entry?');">
+                        <button class="rounded-md bg-rose-600 px-3 py-1 text-xs font-semibold text-white hover:bg-rose-500">Delete</button>
+                      </form>
+                    </td>
+                  </tr>
+                  {% endfor %}
+                  {% if posts|length == 0 %}
+                  <tr>
+                    <td class="px-4 py-6 text-center text-slate-400" colspan="7">No posts saved yet.</td>
+                  </tr>
+                  {% endif %}
+                </tbody>
+              </table>
+            </div>
+          </div>
+        {% endif %}
+      </main>
+    </div>
+  </body>
+</html>
+"""
+
+
+def create_app():
+    app = Flask(__name__)
+
+    @app.route("/")
+    def index():
+        posts = []
+        if is_db_available():
+            rows = fetchPosts(limit=int(os.getenv("TIKBOT_MANAGEMENT_UI_LIMIT", "50")))
+            posts = [
+                {
+                    "post_id": row[0],
+                    "user_id": row[1],
+                    "video_id": row[2],
+                    "platform": row[3],
+                    "posted_at": format_post_time(row[4]),
+                    "discord_message_id": row[5],
+                }
+                for row in rows
+            ]
+        return render_template_string(TEMPLATE, posts=posts, db_available=is_db_available())
+
+    @app.post("/delete/<int:post_id>")
+    def delete_post(post_id):
+        if is_db_available():
+            deletePost(post_id)
+        return redirect(url_for("index"))
+
+    return app
+
+
+def format_post_time(value):
+    if not value:
+        return "-"
+    if isinstance(value, datetime):
+        return value.strftime("%Y-%m-%d %H:%M:%S")
+    return str(value)
+
+
+def run():
+    app = create_app()
+    port = int(os.getenv("TIKBOT_MANAGEMENT_UI_PORT", "8080"))
+    app.run(host="0.0.0.0", port=port, debug=False, use_reloader=False)
+
+
+if __name__ == "__main__":
+    run()

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,4 @@ python-dotenv
 ffmpeg-python
 psycopg2-binary
 requests
+flask


### PR DESCRIPTION
### Motivation
- Provide a simple web-based management UI so saved posts/reposts can be reviewed and deleted during testing.
- Keep the UI lightweight and easy to style by using Tailwind via CDN.
- Make the UI optional and non-blocking so it can run alongside the Discord bot when configured.

### Description
- Add a new `management_ui.py` Flask app that lists recent posts and exposes a `POST /delete/<id>` endpoint with Tailwind UI present in the template.
- Extend `dbInteraction.py` with `is_db_available()`, `fetchPosts(limit)`, and `deletePost(post_id)` and guard DB calls when a connection is not present.
- Start the management UI from `main.py` in a daemon thread via a new `start_management_ui()` function and control it with `TIKBOT_MANAGEMENT_UI_ENABLED` and `TIKBOT_MANAGEMENT_UI_PORT`.
- Add `flask` to `requirements.txt` so the UI dependency is declared.

### Testing
- Attempted to run the UI with `python management_ui.py`, which failed with `ModuleNotFoundError: No module named 'flask'` because the dependency was not available in the environment.
- Attempted to install the dependency with `pip install flask`, which failed due to network/proxy restrictions in the sandbox (package fetch blocked).
- No automated test suite (`pytest`) was run as part of this rollout due to the environment dependency issue.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69521929476c832295eef0c8b72813c3)